### PR TITLE
Add GitHub Action for test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: '30.1'
+      - name: Run tests
+        run: |
+          files=$(find test -name "*.el" -print)
+          emacs -Q --batch -L . $files -l ert -f ert-run-tests-batch-and-exit


### PR DESCRIPTION
## Summary
- add CI workflow to run Emacs tests on push to `main` and PRs

## Testing
- `emacs -Q --batch -L .  -l ert -f ert-run-tests-batch-and-exit` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c418b67e1c832bbf05138a353fe4a2